### PR TITLE
프로젝트 기초 구조 추가와 일정 전체 조회 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ out/
 !**/src/main/**/out/
 !**/src/test/**/out/
 
+
 ### NetBeans ###
 /nbproject/private/
 /nbbuild/

--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,15 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.projectlombok:lombok'
+    implementation 'com.fasterxml.uuid:java-uuid-generator:4.3.0'
+    implementation 'org.mapstruct:mapstruct:1.5.3.Final'
+    annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/jw/clushtest/calendar/config/CalendarEventMapper.java
+++ b/src/main/java/com/jw/clushtest/calendar/config/CalendarEventMapper.java
@@ -1,0 +1,18 @@
+package com.jw.clushtest.calendar.config;
+
+import com.jw.clushtest.calendar.dto.CalendarEventDTO;
+import com.jw.clushtest.calendar.entity.CalendarEventEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface CalendarEventMapper {
+    CalendarEventMapper INSTANCE = Mappers.getMapper(CalendarEventMapper.class);
+
+    @Mapping(target = "id", expression = "java(new String(event.getId(), java.nio.charset.StandardCharsets.UTF_8))")
+    CalendarEventDTO toDTO(CalendarEventEntity event);
+
+    @Mapping(target = "id", expression = "java(dto.getId().getBytes(java.nio.charset.StandardCharsets.UTF_8))")
+    CalendarEventEntity toEntity(CalendarEventDTO dto);
+}

--- a/src/main/java/com/jw/clushtest/calendar/config/UUIDConfig.java
+++ b/src/main/java/com/jw/clushtest/calendar/config/UUIDConfig.java
@@ -1,0 +1,15 @@
+package com.jw.clushtest.calendar.config;
+
+import com.fasterxml.uuid.Generators;
+
+import java.util.UUID;
+
+public class UUIDConfig {
+
+    //UUID 생성기 (하위 비트를 제일 앞으로 정렬)
+    public static byte[] genrateUUID() {
+        UUID uuidV1 = Generators.timeBasedGenerator().generate();
+        String[] uuidArr = uuidV1.toString().split("-");
+        return (uuidArr[2]+"-"+uuidArr[1]+"-"+uuidArr[0]+"-"+uuidArr[3]+"-"+uuidArr[4]).getBytes();
+    }
+}

--- a/src/main/java/com/jw/clushtest/calendar/controller/CalendarEventController.java
+++ b/src/main/java/com/jw/clushtest/calendar/controller/CalendarEventController.java
@@ -1,0 +1,27 @@
+package com.jw.clushtest.calendar.controller;
+
+import com.jw.clushtest.calendar.dto.CalendarEventDTO;
+import com.jw.clushtest.calendar.service.CalendarEventService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/calendar")
+@RequiredArgsConstructor
+public class CalendarEventController {
+
+    private final CalendarEventService eventService;
+
+    //전체 일정 조회
+    @GetMapping("/all")
+    public ResponseEntity<List<CalendarEventDTO>> getAllEvent() {
+        List<CalendarEventDTO> events = eventService.getAllEvents();
+        return ResponseEntity.ok(events);
+    }
+}

--- a/src/main/java/com/jw/clushtest/calendar/dto/CalendarEventDTO.java
+++ b/src/main/java/com/jw/clushtest/calendar/dto/CalendarEventDTO.java
@@ -1,0 +1,24 @@
+package com.jw.clushtest.calendar.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CalendarEventDTO {
+    private String id;
+    private String title;
+    private String description;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime startDate;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime endDate;
+
+}

--- a/src/main/java/com/jw/clushtest/calendar/entity/CalendarEventEntity.java
+++ b/src/main/java/com/jw/clushtest/calendar/entity/CalendarEventEntity.java
@@ -1,0 +1,34 @@
+package com.jw.clushtest.calendar.entity;
+
+import com.jw.clushtest.calendar.config.UUIDConfig;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Table(name = "event")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class CalendarEventEntity {
+
+    @Id
+    @Builder.Default
+    private byte[] id = UUIDConfig.genrateUUID();
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(nullable = false)
+    private LocalDateTime startDate;
+
+    @Column(nullable = false)
+    private LocalDateTime endDate;
+
+}

--- a/src/main/java/com/jw/clushtest/calendar/repository/CalendarEventRepository.java
+++ b/src/main/java/com/jw/clushtest/calendar/repository/CalendarEventRepository.java
@@ -1,0 +1,7 @@
+package com.jw.clushtest.calendar.repository;
+
+import com.jw.clushtest.calendar.entity.CalendarEventEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CalendarEventRepository extends JpaRepository<CalendarEventEntity, String> {
+}

--- a/src/main/java/com/jw/clushtest/calendar/service/CalendarEventService.java
+++ b/src/main/java/com/jw/clushtest/calendar/service/CalendarEventService.java
@@ -1,0 +1,28 @@
+package com.jw.clushtest.calendar.service;
+
+import com.jw.clushtest.calendar.config.CalendarEventMapper;
+import com.jw.clushtest.calendar.dto.CalendarEventDTO;
+import com.jw.clushtest.calendar.repository.CalendarEventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CalendarEventService {
+
+    private final CalendarEventRepository calendarEventRepository;
+    private final CalendarEventMapper mapper = CalendarEventMapper.INSTANCE;
+
+    //일정 전체 조회
+    @Transactional
+    public List<CalendarEventDTO> getAllEvents() {
+        return calendarEventRepository.findAll().stream()
+                .map(mapper::toDTO)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=clush-test

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+spring:
+  application:
+    name: "clush-test"
+
+  datasource:
+    url: jdbc:mysql://localhost:4306/clush_test_calender?characterEncoding=UTF-8&serverTimezone=UTC
+    username: root
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create

--- a/src/test/java/com/jw/clushtest/calendar/controller/CalendarEventControllerTest.java
+++ b/src/test/java/com/jw/clushtest/calendar/controller/CalendarEventControllerTest.java
@@ -1,0 +1,67 @@
+package com.jw.clushtest.calendar.controller;
+
+import com.jw.clushtest.calendar.dto.CalendarEventDTO;
+import com.jw.clushtest.calendar.service.CalendarEventService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(CalendarEventController.class)
+@DisplayName("캘린더 일정 Controller 테스트")
+public class CalendarEventControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CalendarEventService calendarEventService;
+
+    @Test
+    @DisplayName("모든 일정 조회 테스트")
+    public void testGetAllEvents() throws Exception {
+        CalendarEventDTO event1 = new CalendarEventDTO(
+                "11d4-e29b-550e8400-a716-446655440000",
+                "eventTitle1",
+                "eventDescription1",
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1)
+        );
+        CalendarEventDTO event2 = new CalendarEventDTO(
+                "11d4-e29b-550e8401-a716-446655440000",
+                "eventTitle2",
+                "eventDescription2",
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(2)
+        );
+
+        List<CalendarEventDTO> events = Arrays.asList(event1,event2);
+
+        Mockito.when(calendarEventService.getAllEvents()).thenReturn(events);
+
+        mockMvc.perform(get("/api/calendar/all")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value("11d4-e29b-550e8400-a716-446655440000"))
+                .andExpect(jsonPath("$[0].title").value("eventTitle1"))
+                .andExpect(jsonPath("$[1].id").value("11d4-e29b-550e8401-a716-446655440000"))
+                .andExpect(jsonPath("$[1].title").value("eventTitle2"))
+                .andDo(print());
+    }
+}


### PR DESCRIPTION
### 변경 사항
- `CalendarEventMapper` DTO와 Entity의 코드 추가시 매핑을 손쉽게 하기 위해서 MapStruct 라이브러리를 활용했습니다. 
- 추가적인 확장이나 DB병합에 대응하기 위해 고유성이 보장된 UUID를 기본키로 설정하려고 합니다.
     - MySQL에서 정렬을 위해 타임스탬프 기반인 UUIDv1을 사용했습니다. `UUIDConfig`의  `uuidV1` 변수에서 생성됩니다.
     - id는 DTO에서 String으로 사용되고 Mapper를 거쳐서 Entity로 변환되며 byte[]로 변환합니다.
- Test에서 @MockBean이 제거되고 @MockitoBean으로 대체되었습니다.
