### PR TITLE
Feat: 컨트롤러 단일조회, 수정, 삭제 기능 추가, UUID 재구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.projectlombok:lombok'
-    implementation 'com.fasterxml.uuid:java-uuid-generator:4.3.0'
+    implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
     implementation 'org.mapstruct:mapstruct:1.5.3.Final'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'

--- a/src/main/java/com/jw/clushtest/calendar/config/CalendarEventMapper.java
+++ b/src/main/java/com/jw/clushtest/calendar/config/CalendarEventMapper.java
@@ -3,16 +3,16 @@ package com.jw.clushtest.calendar.config;
 import com.jw.clushtest.calendar.dto.CalendarEventDTO;
 import com.jw.clushtest.calendar.entity.CalendarEventEntity;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
+
 import org.mapstruct.factory.Mappers;
+
 
 @Mapper
 public interface CalendarEventMapper {
     CalendarEventMapper INSTANCE = Mappers.getMapper(CalendarEventMapper.class);
 
-    @Mapping(target = "id", expression = "java(new String(event.getId(), java.nio.charset.StandardCharsets.UTF_8))")
     CalendarEventDTO toDTO(CalendarEventEntity event);
 
-    @Mapping(target = "id", expression = "java(dto.getId().getBytes(java.nio.charset.StandardCharsets.UTF_8))")
     CalendarEventEntity toEntity(CalendarEventDTO dto);
+
 }

--- a/src/main/java/com/jw/clushtest/calendar/config/UUIDConfig.java
+++ b/src/main/java/com/jw/clushtest/calendar/config/UUIDConfig.java
@@ -2,14 +2,38 @@ package com.jw.clushtest.calendar.config;
 
 import com.fasterxml.uuid.Generators;
 
+import java.nio.ByteBuffer;
 import java.util.UUID;
 
 public class UUIDConfig {
 
-    //UUID 생성기 (하위 비트를 제일 앞으로 정렬)
-    public static byte[] genrateUUID() {
-        UUID uuidV1 = Generators.timeBasedGenerator().generate();
-        String[] uuidArr = uuidV1.toString().split("-");
-        return (uuidArr[2]+"-"+uuidArr[1]+"-"+uuidArr[0]+"-"+uuidArr[3]+"-"+uuidArr[4]).getBytes();
+    public static UUID generateUUID() {
+        return Generators.timeBasedReorderedGenerator().generate();
+    }
+
+    public static byte[] toBytes(UUID uuid) {
+        ByteBuffer byteBuffer = ByteBuffer.allocate(16);
+        byteBuffer.putLong(uuid.getMostSignificantBits());
+        byteBuffer.putLong(uuid.getLeastSignificantBits());
+        return byteBuffer.array();
+    }
+
+    public static UUID toUUID(byte[] bytes) {
+        ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+        long mostSigBits = byteBuffer.getLong();
+        long leastSigBits = byteBuffer.getLong();
+        return new UUID(mostSigBits, leastSigBits);
+    }
+
+    public static void main(String[] args) {
+       for (int i = 0; i < 10; i++) {
+        UUID uuid1 = Generators.timeBasedReorderedGenerator().generate();
+        System.out.println("UUID 생성: " + uuid1);
+       }
+//        byte[] uuidBytes = toBytes(uuid1);
+//        UUID uuid2 = toUUID(uuidBytes);
+//
+//        System.out.println("UUID byte[] 변환: " + Arrays.toString(uuidBytes));
+//        System.out.println("byte[] UUID 변환: " + uuid2);
     }
 }

--- a/src/main/java/com/jw/clushtest/calendar/config/UUIDConverter.java
+++ b/src/main/java/com/jw/clushtest/calendar/config/UUIDConverter.java
@@ -1,0 +1,19 @@
+package com.jw.clushtest.calendar.config;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.UUID;
+
+@Converter(autoApply = true)
+public class UUIDConverter implements AttributeConverter<UUID, byte[]> {
+    @Override
+    public byte[] convertToDatabaseColumn(UUID attribute) {
+        return attribute == null ? null : UUIDConfig.toBytes(attribute);
+    }
+
+    @Override
+    public UUID convertToEntityAttribute(byte[] dbData) {
+        return dbData == null ? null : UUIDConfig.toUUID(dbData);
+    }
+}

--- a/src/main/java/com/jw/clushtest/calendar/controller/CalendarEventController.java
+++ b/src/main/java/com/jw/clushtest/calendar/controller/CalendarEventController.java
@@ -4,12 +4,10 @@ import com.jw.clushtest.calendar.dto.CalendarEventDTO;
 import com.jw.clushtest.calendar.service.CalendarEventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/calendar")
@@ -19,9 +17,34 @@ public class CalendarEventController {
     private final CalendarEventService eventService;
 
     //전체 일정 조회
-    @GetMapping("/all")
+    @GetMapping
     public ResponseEntity<List<CalendarEventDTO>> getAllEvent() {
         List<CalendarEventDTO> events = eventService.getAllEvents();
         return ResponseEntity.ok(events);
+    }
+
+    //단일 일정 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<CalendarEventDTO> getEventById(@PathVariable UUID id) {
+        return ResponseEntity.ok(eventService.getEventById(id));
+    }
+
+    //일정 생성
+    @PostMapping
+    public ResponseEntity<CalendarEventDTO> createEvent(@RequestBody CalendarEventDTO dto) {
+        return ResponseEntity.ok(eventService.createEvent(dto));
+    }
+
+    //일정 수정
+    @PutMapping("/{id}")
+    public ResponseEntity<CalendarEventDTO> updateEvent(@PathVariable UUID id, @RequestBody CalendarEventDTO dto) {
+        return ResponseEntity.ok(eventService.updateEvent(id,dto));
+    }
+
+    //일정 삭제
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteEvent(@PathVariable UUID id) {
+        eventService.deleteEvent(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/jw/clushtest/calendar/dto/CalendarEventDTO.java
+++ b/src/main/java/com/jw/clushtest/calendar/dto/CalendarEventDTO.java
@@ -1,10 +1,11 @@
 package com.jw.clushtest.calendar.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.jw.clushtest.calendar.config.UUIDConfig;
+import jakarta.persistence.PrePersist;
 import lombok.*;
-import org.springframework.format.annotation.DateTimeFormat;
-
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -12,7 +13,8 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 public class CalendarEventDTO {
-    private String id;
+
+    private UUID id;
     private String title;
     private String description;
 

--- a/src/main/java/com/jw/clushtest/calendar/entity/CalendarEventEntity.java
+++ b/src/main/java/com/jw/clushtest/calendar/entity/CalendarEventEntity.java
@@ -1,14 +1,14 @@
 package com.jw.clushtest.calendar.entity;
 
-import com.jw.clushtest.calendar.config.UUIDConfig;
+import com.jw.clushtest.calendar.config.UUIDConverter;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Table(name = "event")
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -16,8 +16,9 @@ import java.time.LocalDateTime;
 public class CalendarEventEntity {
 
     @Id
-    @Builder.Default
-    private byte[] id = UUIDConfig.genrateUUID();
+    @Column(columnDefinition = "BINARY(16)")
+    @Convert(converter = UUIDConverter.class)
+    private UUID id;
 
     @Column(nullable = false)
     private String title;
@@ -30,5 +31,6 @@ public class CalendarEventEntity {
 
     @Column(nullable = false)
     private LocalDateTime endDate;
+
 
 }

--- a/src/main/java/com/jw/clushtest/calendar/repository/CalendarEventRepository.java
+++ b/src/main/java/com/jw/clushtest/calendar/repository/CalendarEventRepository.java
@@ -1,7 +1,10 @@
 package com.jw.clushtest.calendar.repository;
 
+import com.jw.clushtest.calendar.dto.CalendarEventDTO;
 import com.jw.clushtest.calendar.entity.CalendarEventEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CalendarEventRepository extends JpaRepository<CalendarEventEntity, String> {
+import java.util.UUID;
+
+public interface CalendarEventRepository extends JpaRepository<CalendarEventEntity, UUID> {
 }

--- a/src/main/java/com/jw/clushtest/calendar/service/CalendarEventService.java
+++ b/src/main/java/com/jw/clushtest/calendar/service/CalendarEventService.java
@@ -1,6 +1,7 @@
 package com.jw.clushtest.calendar.service;
 
 import com.jw.clushtest.calendar.config.CalendarEventMapper;
+import com.jw.clushtest.calendar.config.UUIDConfig;
 import com.jw.clushtest.calendar.dto.CalendarEventDTO;
 import com.jw.clushtest.calendar.repository.CalendarEventRepository;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -25,4 +27,41 @@ public class CalendarEventService {
                 .collect(Collectors.toList());
     }
 
+    //특정 일정 조회
+    @Transactional
+    public CalendarEventDTO getEventById(UUID id) {
+        return calendarEventRepository.findById(id)
+                .map(mapper::toDTO)
+                .orElseThrow(() -> new IllegalArgumentException("일정을 찾을 수 없습니다."));
+    }
+
+    //일정 생성
+    @Transactional
+    public CalendarEventDTO createEvent(CalendarEventDTO eventDTO) {
+        if(eventDTO.getId() == null) {
+            eventDTO.setId(UUIDConfig.generateUUID());
+        }
+        return mapper.toDTO(calendarEventRepository.save(mapper.toEntity(eventDTO)));
+    }
+
+    //일정 수정
+    @Transactional
+    public CalendarEventDTO updateEvent(UUID id, CalendarEventDTO calendarEventDTO) {
+        CalendarEventDTO eventDTO = calendarEventRepository.findById(id)
+                .map(mapper::toDTO)
+                .orElseThrow(()-> new IllegalArgumentException("일정을 찾을 수 없습니다."));
+        eventDTO.setTitle(calendarEventDTO.getTitle());
+        eventDTO.setDescription(calendarEventDTO.getDescription());
+        eventDTO.setStartDate(calendarEventDTO.getStartDate());
+        eventDTO.setEndDate(calendarEventDTO.getEndDate());
+        mapper.toDTO(calendarEventRepository.save(mapper.toEntity(eventDTO)));
+
+        return eventDTO;
+    }
+
+    //일정 삭제
+    @Transactional
+    public void deleteEvent(UUID id) {
+        calendarEventRepository.deleteById(id);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,9 +3,19 @@ spring:
     name: "clush-test"
 
   datasource:
-    url: jdbc:mysql://localhost:4306/clush_test_calender?characterEncoding=UTF-8&serverTimezone=UTC
+    url: jdbc:mysql://localhost:4306/clush_test_calendar?characterEncoding=UTF-8&serverTimezone=UTC
     username: root
     password:
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
       ddl-auto: create
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQLDialect
+    generate-ddl: false
+    show-sql: true
+    properties:
+      hibernate.hibernate.format_sql: true
+
+server:
+  port: 8093

--- a/src/test/java/com/jw/clushtest/calendar/controller/CalendarEventControllerTest.java
+++ b/src/test/java/com/jw/clushtest/calendar/controller/CalendarEventControllerTest.java
@@ -1,5 +1,6 @@
 package com.jw.clushtest.calendar.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jw.clushtest.calendar.dto.CalendarEventDTO;
 import com.jw.clushtest.calendar.service.CalendarEventService;
 import org.junit.jupiter.api.DisplayName;
@@ -16,8 +17,12 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -30,38 +35,170 @@ public class CalendarEventControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @MockitoBean
     private CalendarEventService calendarEventService;
 
     @Test
     @DisplayName("모든 일정 조회 테스트")
     public void testGetAllEvents() throws Exception {
-        CalendarEventDTO event1 = new CalendarEventDTO(
-                "11d4-e29b-550e8400-a716-446655440000",
-                "eventTitle1",
-                "eventDescription1",
-                LocalDateTime.now(),
-                LocalDateTime.now().plusDays(1)
-        );
-        CalendarEventDTO event2 = new CalendarEventDTO(
-                "11d4-e29b-550e8401-a716-446655440000",
-                "eventTitle2",
-                "eventDescription2",
-                LocalDateTime.now(),
-                LocalDateTime.now().plusDays(2)
-        );
+
+        CalendarEventDTO event1 = CalendarEventDTO.builder()
+                .id(UUID.fromString("1efe625b-1b71-69c6-a237-611b6a789114"))
+                .title("eventTitle1")
+                .description("eventDescription1")
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(1))
+                .build();
+
+        CalendarEventDTO event2 = CalendarEventDTO.builder()
+                .id(UUID.fromString("1efe625b-1b71-69c6-a237-611b6a789114"))
+                .title("eventTitle2")
+                .description("eventDescription2")
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(2))
+                .build();
+
 
         List<CalendarEventDTO> events = Arrays.asList(event1,event2);
 
         Mockito.when(calendarEventService.getAllEvents()).thenReturn(events);
 
-        mockMvc.perform(get("/api/calendar/all")
+        mockMvc.perform(get("/api/calendar")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].id").value("11d4-e29b-550e8400-a716-446655440000"))
+                .andExpect(jsonPath("$[0].id").value(event1.getId().toString()))
                 .andExpect(jsonPath("$[0].title").value("eventTitle1"))
-                .andExpect(jsonPath("$[1].id").value("11d4-e29b-550e8401-a716-446655440000"))
+                .andExpect(jsonPath("$[1].id").value(event2.getId().toString()))
                 .andExpect(jsonPath("$[1].title").value("eventTitle2"))
                 .andDo(print());
+    }
+
+    @Test
+    @DisplayName("단일 일정 조회 테스트")
+    public void testGetEventById() throws Exception {
+
+        CalendarEventDTO event1 = CalendarEventDTO.builder()
+                .id(UUID.fromString("1efe625b-1b71-69c6-a237-611b6a789114"))
+                .title("eventTitle1")
+                .description("eventDescription1")
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(1))
+                .build();
+
+        Mockito.when(calendarEventService.getEventById(event1.getId())).thenReturn(event1);
+
+        mockMvc.perform(get("/api/calendar/{id}", event1.getId())
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(event1.getId().toString()))
+                .andExpect(jsonPath("$.title").value("eventTitle1"))
+                .andExpect(jsonPath("$.description").value("eventDescription1"))
+                .andDo(print());
+        Mockito.verify(calendarEventService, times(1)).getEventById(event1.getId());
+    }
+
+    @Test
+    @DisplayName("일정 생성 테스트")
+    public void testCreateEvent() throws Exception {
+
+        CalendarEventDTO eventDTO = CalendarEventDTO.builder()
+                .title("eventTitle1")
+                .description("eventDescription1")
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(1))
+                .build();
+
+        CalendarEventDTO responseDTO = CalendarEventDTO.builder()
+                .id(UUID.randomUUID()) // 서비스에서 생성된 UUID 가정
+                .title(eventDTO.getTitle())
+                .description(eventDTO.getDescription())
+                .startDate(eventDTO.getStartDate())
+                .endDate(eventDTO.getEndDate())
+                .build();
+
+        Mockito.when(calendarEventService.createEvent(any(CalendarEventDTO.class)))
+                .thenReturn(responseDTO);
+
+        mockMvc.perform(post("/api/calendar")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(eventDTO)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(responseDTO.getId().toString()))
+                .andExpect(jsonPath("$.title").value(responseDTO.getTitle()))
+                .andExpect(jsonPath("$.description").value(responseDTO.getDescription()))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("일정 수정 테스트")
+    public void testUpdateEvent() throws Exception {
+        //일정 생성
+        CalendarEventDTO createDto = CalendarEventDTO.builder()
+                .id(UUID.randomUUID())
+                .title("Original Event Title")
+                .description("Original Event Description")
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(1))
+                .build();
+
+        Mockito.when(calendarEventService.createEvent(any(CalendarEventDTO.class))).thenReturn(createDto);
+
+        mockMvc.perform(post("/api/calendar")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(createDto.getId().toString()))
+                .andExpect(jsonPath("$.title").value(createDto.getTitle()))
+                .andExpect(jsonPath("$.description").value(createDto.getDescription()))
+                .andExpect(jsonPath("$.startDate").exists())
+                .andExpect(jsonPath("$.endDate").exists())
+                .andDo(print());
+
+        //일정 수정
+        CalendarEventDTO updateDto = CalendarEventDTO.builder()
+                .id(createDto.getId())
+                .title("Update Event Title")
+                .description("Update Event Description")
+                .startDate(createDto.getStartDate().plusDays(1))
+                .endDate(createDto.getEndDate().plusDays(1))
+                .build();
+
+        Mockito.when(calendarEventService.updateEvent(eq(createDto.getId()), any(CalendarEventDTO.class))).thenReturn(updateDto);
+
+        mockMvc.perform(put("/api/calendar/{id}" , createDto.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(updateDto.getId().toString()))
+                .andExpect(jsonPath("$.title").value(updateDto.getTitle()))
+                .andExpect(jsonPath("$.description").value(updateDto.getDescription()))
+                .andExpect(jsonPath("$.startDate").exists())
+                .andExpect(jsonPath("$.endDate").exists())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("일정 삭제")
+    public void testDeleteEvent() throws Exception {
+        //일정 생성
+        CalendarEventDTO createDto = CalendarEventDTO.builder()
+                .id(UUID.randomUUID())
+                .title("Event Title")
+                .description("Event Description")
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(1))
+                .build();
+
+        Mockito.doNothing().when(calendarEventService).deleteEvent(createDto.getId());
+
+        mockMvc.perform(delete("/api/calendar/{id}" , createDto.getId())
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent())
+                .andDo(print());
+
+        Mockito.verify(calendarEventService, times(1)).deleteEvent(createDto.getId());
     }
 }


### PR DESCRIPTION
### 변경사항
- `CalendarEventMapper` 의 byte/uuid convert 방식을 mapper에서 바꾸는게 아니라 Entity의 byte[] 타입으로 저장되는 방식을 UUID 타입으로 변경하고, `UUIDConverter` 클래스를 거쳐 변환을 수행하고 `CalendarEventEntity`에서 저장하도록 변경하였습니다.
     - 변경 이유는 Test시 기존의 byte/uuid Converting 방식이 잘못 적용됐다는 사실을 알게되었습니다. UUID로 id를 받아 byte로 변경하는 시점의 문제가 있었고, 정상적으로 Convert되지 않았습니다. 
- Controller의 URL 매핑 방식을 RESTful 방식으로 변경하였습니다.
- 모든 단위 테스트를 수행했습니다.