### PR TITLE
Feat: 일정 데이터 QR Code 생성 추가, GlobalException 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
-
+*.yml
 
 ### NetBeans ###
 /nbproject/private/

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.projectlombok:lombok'
     implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+    implementation 'com.google.zxing:core:3.5.3'
+    implementation 'com.google.zxing:javase:3.5.3'
     implementation 'org.mapstruct:mapstruct:1.5.3.Final'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'

--- a/src/main/java/com/jw/clushtest/calendar/dto/CalendarEventDTO.java
+++ b/src/main/java/com/jw/clushtest/calendar/dto/CalendarEventDTO.java
@@ -18,9 +18,9 @@ public class CalendarEventDTO {
     private String title;
     private String description;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime startDate;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime endDate;
 
 }

--- a/src/main/java/com/jw/clushtest/calendar/exception/AppErrorCode.java
+++ b/src/main/java/com/jw/clushtest/calendar/exception/AppErrorCode.java
@@ -1,0 +1,23 @@
+package com.jw.clushtest.calendar.exception;
+
+public enum AppErrorCode {
+    INVALID_REQUEST(400, "잘못된 요청입니다."),
+    NOT_FOUND(404, "리소스를 찾을 수 없습니다."),
+    INTERNAL_SERVER_ERROR(500, "서버 내부 오류입니다.");
+
+    private final int statusNum;
+    private final String message;
+
+    AppErrorCode(int statusNum, String message) {
+        this.statusNum = statusNum;
+        this.message = message;
+    }
+
+    public int getStatusNum() {
+        return statusNum;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/jw/clushtest/calendar/exception/AppErrorResponse.java
+++ b/src/main/java/com/jw/clushtest/calendar/exception/AppErrorResponse.java
@@ -1,0 +1,28 @@
+package com.jw.clushtest.calendar.exception;
+
+public class AppErrorResponse {
+    private int status;
+    private String message;
+
+    public AppErrorResponse(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public void setStatus(int status) {
+        this.status = status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+}

--- a/src/main/java/com/jw/clushtest/calendar/exception/AppException.java
+++ b/src/main/java/com/jw/clushtest/calendar/exception/AppException.java
@@ -1,0 +1,8 @@
+package com.jw.clushtest.calendar.exception;
+
+public class AppException extends RuntimeException {
+
+    public AppException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/jw/clushtest/calendar/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/jw/clushtest/calendar/exception/GlobalExceptionHandler.java
@@ -1,0 +1,49 @@
+package com.jw.clushtest.calendar.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.io.IOException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<AppErrorResponse> handleValidationException(MethodArgumentNotValidException ex) {
+        AppErrorResponse appErrorResponse = new AppErrorResponse(
+                AppErrorCode.INVALID_REQUEST.getStatusNum(),
+                AppErrorCode.INVALID_REQUEST.getMessage());
+
+        return new ResponseEntity<>(appErrorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(AppException.class)
+    public ResponseEntity<AppErrorResponse> handleNotFoundException(AppException ex) {
+        AppErrorResponse appErrorResponse = new AppErrorResponse(
+                AppErrorCode.NOT_FOUND.getStatusNum(),
+                ex.getMessage() != null ? ex.getMessage() : AppErrorCode.NOT_FOUND.getMessage());
+
+        return new ResponseEntity<>(appErrorResponse, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<AppErrorResponse> handleException(Exception ex) {
+        AppErrorResponse appErrorResponse = new AppErrorResponse(
+                AppErrorCode.INTERNAL_SERVER_ERROR.getStatusNum(),
+                AppErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+
+        return new ResponseEntity<>(appErrorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(IOException.class)
+    public ResponseEntity<AppErrorResponse> handleIOException(IOException ex) {
+        AppErrorResponse appErrorResponse = new AppErrorResponse(
+                AppErrorCode.INTERNAL_SERVER_ERROR.getStatusNum(),
+                "입출력 오류가 발생했습니다.");
+
+        return new ResponseEntity<>(appErrorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/jw/clushtest/calendar/repository/CalendarEventRepository.java
+++ b/src/main/java/com/jw/clushtest/calendar/repository/CalendarEventRepository.java
@@ -4,7 +4,10 @@ import com.jw.clushtest.calendar.dto.CalendarEventDTO;
 import com.jw.clushtest.calendar.entity.CalendarEventEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public interface CalendarEventRepository extends JpaRepository<CalendarEventEntity, UUID> {
+    List<CalendarEventEntity> findByStartDateBetween(LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/jw/clushtest/calendar/service/CalendarEventService.java
+++ b/src/main/java/com/jw/clushtest/calendar/service/CalendarEventService.java
@@ -3,11 +3,16 @@ package com.jw.clushtest.calendar.service;
 import com.jw.clushtest.calendar.config.CalendarEventMapper;
 import com.jw.clushtest.calendar.config.UUIDConfig;
 import com.jw.clushtest.calendar.dto.CalendarEventDTO;
+import com.jw.clushtest.calendar.entity.CalendarEventEntity;
 import com.jw.clushtest.calendar.repository.CalendarEventRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -63,5 +68,22 @@ public class CalendarEventService {
     @Transactional
     public void deleteEvent(UUID id) {
         calendarEventRepository.deleteById(id);
+    }
+
+
+    //지정 월 일정 조회
+    @Transactional
+    public List<CalendarEventDTO> getEventsForCurrentMonth() {
+        LocalDate today = LocalDate.now();
+        LocalDate startOfMonth = today.withDayOfMonth(1);
+        LocalDate endOfMonth = today.with(TemporalAdjusters.lastDayOfMonth());
+
+        LocalDateTime startDate = startOfMonth.atStartOfDay();
+        LocalDateTime endDate = endOfMonth.atTime(LocalTime.MAX);
+
+        return calendarEventRepository.findByStartDateBetween(startDate, endDate)
+                .stream()
+                .map(mapper::toDTO)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/jw/clushtest/qr/controller/QrController.java
+++ b/src/main/java/com/jw/clushtest/qr/controller/QrController.java
@@ -1,0 +1,22 @@
+package com.jw.clushtest.qr.controller;
+
+import com.jw.clushtest.qr.service.QrCodeService;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/api/share")
+@RequiredArgsConstructor
+public class QrController {
+    private final QrCodeService qrCodeService;
+
+    @GetMapping("/qr")
+    public ResponseEntity<byte[]> getCalendarQR() throws Exception {
+        return qrCodeService.getCalendarQR();
+    }
+}

--- a/src/main/java/com/jw/clushtest/qr/service/QrCodeService.java
+++ b/src/main/java/com/jw/clushtest/qr/service/QrCodeService.java
@@ -1,0 +1,63 @@
+package com.jw.clushtest.qr.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.EncodeHintType;
+import com.google.zxing.client.j2se.MatrixToImageWriter;
+import com.google.zxing.common.BitMatrix;
+import com.google.zxing.qrcode.QRCodeWriter;
+import com.jw.clushtest.calendar.dto.CalendarEventDTO;
+import com.jw.clushtest.calendar.service.CalendarEventService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class QrCodeService {
+
+    private final CalendarEventService eventService;
+    private final ObjectMapper objectMapper;
+
+    public ResponseEntity<byte[]> getCalendarQR() throws Exception {
+        List<CalendarEventDTO> events = eventService.getEventsForCurrentMonth();
+
+        List<CalendarEventDTO> eventsRemoveId = events.stream()
+                .map(event -> {
+                    event.setId(null); // id 필드 값을 null로 설정
+                    return event;
+                })
+                .collect(Collectors.toList());
+
+        String jsonData = objectMapper.writeValueAsString(eventsRemoveId);
+
+        byte[] qrImage = generateQRCode(jsonData, 300, 300);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.IMAGE_PNG);
+        return new ResponseEntity<>(qrImage, headers, HttpStatus.OK);
+    }
+
+    public byte[] generateQRCode(String text, int width, int height) throws Exception {
+        QRCodeWriter qrCodeWriter = new QRCodeWriter();
+
+        Map<EncodeHintType, Object> hints = new HashMap<>();
+        hints.put(EncodeHintType.CHARACTER_SET, "UTF-8"); // QR 변환시 한글 출력 인코딩 타입
+
+        BitMatrix bitMatrix = qrCodeWriter.encode(text, BarcodeFormat.QR_CODE, width, height, hints);
+        ByteArrayOutputStream pngOutputStream = new ByteArrayOutputStream();
+        MatrixToImageWriter.writeToStream(bitMatrix, "PNG", pngOutputStream);
+        return pngOutputStream.toByteArray();
+    }
+}


### PR DESCRIPTION
### 변경사항

- `CalendarEventDTO` 의 JSONformat을 FrontEnd 생성 기준 점에 맞춰서 초 단위를 삭제하였습니다.
- `zxing` 라이브러리를 추가해 일정 공유 QR API를 만들었습니다.
     - `getEventsForCurrentMonth` 메서드로 한달 기준 모든 일자의 일정 데이터를 조회합니다.
     - `getCalendarQR` 에서 이벤트를 UUID로 지정된 id를 null로 바꾸고 일정 데이터를 가져옵니다.
     - `generateQRCode` 로 해당 일정 데이터를 QR코드로 바꿉니다.
     - 한글 인코딩 문제로 `EncodeHintType` 를 추가해 문자 인코딩을 UTF-8 로 타입 지정을 해주었습니다.
- `GlobalExceptionHandler` 를 추가하여 예외처리를 중앙 집중화 시켰습니다.